### PR TITLE
add `BlockQuote` component

### DIFF
--- a/.changeset/tidy-falcons-help.md
+++ b/.changeset/tidy-falcons-help.md
@@ -1,0 +1,6 @@
+---
+"@jimmydalecleveland/stitches-ui-example": minor
+"web": minor
+---
+
+The `BlockQuote` component has been added for a simple way to get a stylized blockquote.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,16 @@
 // noinspection HtmlRequiredTitleElement
 
 import type { Metadata } from "next";
+import "@fontsource/karla/300.css";
+import "@fontsource/karla/400.css";
+import "@fontsource/karla/500.css";
+import "@fontsource/karla/600.css";
+import "@fontsource/karla/700.css";
+import "@fontsource/texturina/300.css";
+import "@fontsource/texturina/400.css";
+import "@fontsource/texturina/500.css";
+import "@fontsource/texturina/600.css";
+import "@fontsource/texturina/700.css";
 import {
   getCssText,
   globalStyles,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,5 @@
 import {
+  BlockQuote,
   Box,
   Button,
   Card,
@@ -83,6 +84,11 @@ export default function Page(): React.ReactElement {
               </Stack>
             </Column>
           </Columns>
+          <BlockQuote>
+            But that was civilisation, so far as Logen could tell. People with
+            nothing better to do, dreaming up ways to make easy things
+            difficult.
+          </BlockQuote>
         </Stack>
       </Box>
     </main>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/karla": "^5.0.17",
+    "@fontsource/texturina": "^5.0.17",
     "@jimmydalecleveland/stitches-ui-example": "*",
     "next": "^13.4.19",
     "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,10 @@
       }
     },
     "apps/web": {
-      "version": "1.5.0",
+      "version": "1.8.0",
       "dependencies": {
+        "@fontsource/karla": "^5.0.17",
+        "@fontsource/texturina": "^5.0.17",
         "@jimmydalecleveland/stitches-ui-example": "*",
         "next": "^13.4.19",
         "react": "^18.2.0",
@@ -20282,7 +20284,7 @@
     },
     "packages/ui": {
       "name": "@jimmydalecleveland/stitches-ui-example",
-      "version": "0.6.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource/karla": "^5.0.17",

--- a/packages/ui/src/BlockQuote/BlockQuote.stories.tsx
+++ b/packages/ui/src/BlockQuote/BlockQuote.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta } from "@storybook/react";
+import { BlockQuote } from ".";
+
+export default {
+  title: "Components/BlockQuote",
+  component: BlockQuote,
+} satisfies Meta<typeof BlockQuote>;
+
+export const Default = {
+  args: {
+    children:
+      "But that was civilisation, so far as Logen could tell. People with nothing better to do, dreaming up ways to make easy things difficult.",
+  },
+};

--- a/packages/ui/src/BlockQuote/BlockQuote.tsx
+++ b/packages/ui/src/BlockQuote/BlockQuote.tsx
@@ -1,0 +1,27 @@
+import { Column, Columns } from "../Columns";
+import { Text } from "../Text";
+import Quote from "./Quote";
+
+export interface BlockQuoteProps {
+  children: React.ReactNode;
+  citationLink?: string;
+}
+
+const BlockQuote = ({ children, citationLink }: BlockQuoteProps) => {
+  return (
+    <Columns space="04" alignY="top">
+      <Column width="content">
+        <Quote />
+      </Column>
+      <Column>
+        <blockquote cite={citationLink} style={{ margin: 0 }}>
+          <Text as="p" size="xl" vibe="subdued" weight="heavy">
+            {children}
+          </Text>
+        </blockquote>
+      </Column>
+    </Columns>
+  );
+};
+
+export default BlockQuote;

--- a/packages/ui/src/BlockQuote/Quote.tsx
+++ b/packages/ui/src/BlockQuote/Quote.tsx
@@ -1,0 +1,12 @@
+import { styled } from "../theme/stitches.config";
+
+const QuoteSymbol = styled("span", {
+  fontFamily: "$body",
+  fontSize: "6rem",
+  color: "$textNeutral",
+  lineHeight: 0.8,
+});
+
+const Quote = () => <QuoteSymbol>&quot;</QuoteSymbol>;
+
+export default Quote;

--- a/packages/ui/src/BlockQuote/index.ts
+++ b/packages/ui/src/BlockQuote/index.ts
@@ -1,0 +1,1 @@
+export { default as BlockQuote } from "./BlockQuote";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 // component exports
 export * from "./Box";
 export * from "./Button";
+export * from "./BlockQuote";
 export * from "./Card";
 export * from "./Columns";
 export * from "./Divider";


### PR DESCRIPTION
I ran into a little snag on this one, apparently Next.js server components are not compatible with Stitches `css` styles because you have to run a function in a component, which only server components are allowed to do.

I just converted it to use `styled` but it was a bit annoying.
