### PR TITLE
breadcrumbs component

### DIFF
--- a/.changeset/happy-mails-mate.md
+++ b/.changeset/happy-mails-mate.md
@@ -1,0 +1,6 @@
+---
+"@jimmydalecleveland/stitches-ui-example": patch
+"web": patch
+---
+
+A bug was fixed where the themes `$body` font family was not being set by default. It was working correctly in Storybook but not in the demo Next.js app.

--- a/.changeset/tame-bottles-destroy.md
+++ b/.changeset/tame-bottles-destroy.md
@@ -1,0 +1,6 @@
+---
+"@jimmydalecleveland/stitches-ui-example": minor
+"web": minor
+---
+
+`Breadcrumbs` has been added, allowing for a simpler way to create an interactive breadcrumb trail of where the user is at in an app.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,12 +2,14 @@ import {
   ArrowRight,
   BlockQuote,
   Box,
+  Breadcrumbs,
   Button,
   Card,
   Check,
   Column,
   Columns,
   Heading,
+  Home,
   Inline,
   Link,
   List,
@@ -23,6 +25,20 @@ export default function Page(): React.ReactElement {
     <main>
       <Box padding="04">
         <Stack space="06">
+          <Breadcrumbs>
+            <Link href="/">
+              <Home size="xs" vibe="attract" />
+            </Link>
+            <Link href="/#example" key={0} size="xs">
+              Products
+            </Link>
+            <Link href="/#example" key={1} size="xs">
+              Category
+            </Link>
+            <Text key={2} size="xs" weight="medium">
+              Page Name
+            </Text>
+          </Breadcrumbs>
           <Box vibe="neutral">
             <Heading size="h1">Welcome to the Stitches Design System</Heading>
             <Text as="p">

--- a/packages/ui/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/ui/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta } from "@storybook/react";
+import { Link } from "../Link";
+import { Text } from "../Text";
+import { Home } from "../Icon";
+import { Breadcrumbs } from "./index";
+
+export default {
+  title: "Components/Breadcrumbs",
+  component: Breadcrumbs,
+} as Meta<typeof Breadcrumbs>;
+
+export const Default = {
+  args: {
+    children: (
+      <>
+        <Link href="/">
+          <Home vibe="attract" size="xs" />
+        </Link>
+        <Link href="/#example" key={0} size="xs">
+          Products
+        </Link>
+        <Link href="/#example" key={1} size="xs">
+          Category
+        </Link>
+        <Text key={2} size="xs" weight="medium">
+          Page Name
+        </Text>
+      </>
+    ),
+  },
+};

--- a/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { Inline } from "../Inline";
+import { ChevronRight } from "../Icon";
+import type { ThemeSpace } from "../theme/stitches.config";
+import flattenFragments from "../utils/flattenFragments";
+
+export interface BreadcrumbsProps {
+  children: React.ReactNode;
+  space?: ThemeSpace;
+  size?: "sm" | "md" | "lg" | "xl" | "xs";
+}
+
+/**
+ * Styles should come from each individual child component in order to make it possible to render a next/link, a Link component, Text, etc.
+ * The size prop applies to the arrow icon only.
+ */
+const Breadcrumbs = ({
+  children,
+  space = "01",
+  size = "xs",
+}: BreadcrumbsProps) => {
+  const breadcrumbsChildren = flattenFragments(
+    React.Children.toArray(children),
+  );
+
+  return (
+    <Inline space={space} role="navigation" aria-label="breadcrumbs">
+      {breadcrumbsChildren.map((child, index) => {
+        // Don't render anything if the child is not an element.
+        if (!React.isValidElement(child)) return null;
+
+        const isLast = index === breadcrumbsChildren.length - 1;
+        return (
+          <React.Fragment key={child.key}>
+            {child}
+            {!isLast && <ChevronRight vibe="disabled" size={size} />}
+          </React.Fragment>
+        );
+      })}
+    </Inline>
+  );
+};
+
+export default Breadcrumbs;

--- a/packages/ui/src/Breadcrumbs/index.ts
+++ b/packages/ui/src/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { default as Breadcrumbs } from "./Breadcrumbs";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,8 @@
 // component exports
-export * from "./Box";
-export * from "./Button";
 export * from "./BlockQuote";
+export * from "./Box";
+export * from "./Breadcrumbs";
+export * from "./Button";
 export * from "./Card";
 export * from "./Columns";
 export * from "./Divider";

--- a/packages/ui/src/theme/stitches.config.ts
+++ b/packages/ui/src/theme/stitches.config.ts
@@ -244,6 +244,7 @@ export const globalStyles = globalCss({
     margin: 0,
     backgroundColor: "$boxSubdued",
     height: "100%",
+    fontFamily: "$body",
   },
 
   // required to push footer to bottom in inner layout from Next.js


### PR DESCRIPTION
- fix: default `$body` font family not being applied
- add `Breadcrumbs` component, story, and web app usage example
